### PR TITLE
let user to input their name and email for git

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,13 +90,14 @@ brew_install imagemagick
 brew_install catimg
 
 # link git config
+git_username=`git config --get user.name`
+git_email=`git config --get user.email`
+
 mv ~/.gitconfig ~/.gitconfig_backup
 ln -s ~/.macbootstrap/git-config/.gitconfig ~/.gitconfig
 
-read -p "please input your username for Git:" name
-read -p "please input youer email for Git:" email
-git config --global user.name "$name"
-git config --global user.email "$email"
+git config --global user.name "$git_username"
+git config --global user.email "$git_email"
 
 if [[ ! -e ~/.oh-my-zsh ]]; then
     curl -L https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh | sh

--- a/install.sh
+++ b/install.sh
@@ -93,6 +93,11 @@ brew_install catimg
 mv ~/.gitconfig ~/.gitconfig_backup
 ln -s ~/.macbootstrap/git-config/.gitconfig ~/.gitconfig
 
+read -p "please input your username for Git:" name
+read -p "please input youer email for Git:" email
+git config --global user.name "$name"
+git config --global user.email "$email"
+
 if [[ ! -e ~/.oh-my-zsh ]]; then
     curl -L https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh | sh
 fi


### PR DESCRIPTION
In order to avoid the username and email in .gitconfig being replaced, I modify the install.sh to let user to input their name and email for Git. 
We also can simply delete the username and email in .gitconfig, however, when user use git commit, the git will ask you to set up the identity info. 