### PR TITLE
Git GPG配置

### DIFF
--- a/doc/git.md
+++ b/doc/git.md
@@ -20,6 +20,7 @@
 5. 输入 `git config --global user.signingkey ID` 来配置使用哪个 key。
 6. 单次提交时使用 `git commit -S` 参数来开启 GPG key，或者使用 `git config --global commit.gpgsign true` 设置为全局默认使用
 7. 输入 `gvc <commit_hash>` 来检查某次提交的 GPG 签名情况，如果没有输出，说明没有签名。它是`git verify-commit` 命令的缩写
+8. 如果遇见签名失败的情况,可尝试将 `export GPG_TTY=$(tty)` 添加到自己的 shell 配置文件中  
 
 ## git log
 

--- a/doc/git.md
+++ b/doc/git.md
@@ -18,7 +18,7 @@
 3. 安装完成后输入 `gpg --list-keys` 查看刚刚生成的秘钥，在 pub 下面有一长串数字和字母，这个是 ID
 4. 输入 `gpg --armor --export pub GPG ID` 把公钥复制出来，拷贝到 [GitHub GPG Keys](https://github.com/settings/keys) 上
 5. 输入 `git config --global user.signingkey ID` 来配置使用哪个 key。
-6. 单次提交时使用 `git commit -s` 参数来开启 GPG key，或者使用 `git config --global commit.gpgsign true` 设置为全局默认使用
+6. 单次提交时使用 `git commit -S` 参数来开启 GPG key，或者使用 `git config --global commit.gpgsign true` 设置为全局默认使用
 7. 输入 `gvc <commit_hash>` 来检查某次提交的 GPG 签名情况，如果没有输出，说明没有签名。它是`git verify-commit` 命令的缩写
 
 ## git log


### PR DESCRIPTION
1. -s 只会在 commit message log 的最后一行加上一个作者邮箱， -S 才能使用 GPG 签名。
2. 我在配置 GPG 密钥的过程中，总是签名失败。
后来查了下 [Github](https://help.github.com/articles/telling-git-about-your-gpg-key/) 的文档，在第五步看到了需要配置 `GPG_TTY ` 这个环境变量。这个环境变量的作用 [gpg](https://www.gnupg.org/documentation/manuals/gnupg/Invoking-GPG_002dAGENT.html)